### PR TITLE
Fix mobile hero: navbar overlap and ecosystem clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ permalink: /
 <!-- ============================================ -->
 <!-- HERO (DARK)                                   -->
 <!-- ============================================ -->
-<section class="relative min-h-screen flex items-center justify-center dark-section overflow-hidden" style="background-color: #0a0118;">
+<section class="relative min-h-screen flex items-center justify-center dark-section overflow-hidden pt-20" style="background-color: #0a0118;">
     <!-- Animated Network Background (Canvas) -->
     <canvas id="hero-network" class="absolute inset-0 w-full h-full"></canvas>
     <!-- Decorative Purple Blur Blobs -->
@@ -59,7 +59,7 @@ permalink: /
     <div class="absolute bottom-1/3 right-1/4 w-80 h-80 bg-brand-500/15 rounded-full blur-3xl"></div>
     <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-brand-800/10 rounded-full blur-3xl"></div>
 
-    <div class="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-20">
         <!-- Two-Tile Hero -->
         <div class="grid md:grid-cols-2 gap-8 lg:gap-12 mb-12">
             <!-- Builders -->
@@ -79,7 +79,7 @@ permalink: /
             <div class="text-center mb-8">
                 <span class="text-sm font-semibold uppercase tracking-wider text-white/70">Ecosystem</span>
             </div>
-            <div class="relative mx-auto" style="width: 280px; height: 280px;">
+            <div class="relative mx-auto" style="width: 280px; height: 320px;">
                 <!-- Circular ring -->
                 <svg class="absolute inset-0 w-full h-full" viewBox="0 0 280 280">
                     <circle cx="140" cy="140" r="110" fill="none" stroke="rgba(255,255,255,0.12)" stroke-width="2"/>


### PR DESCRIPTION
- Add top padding to hero section so cards aren't hidden behind fixed navbar
- Add bottom padding to push ecosystem above wave divider
- Increase ecosystem container height to prevent "Projects" node from being clipped